### PR TITLE
[Fixes #21] - Add newline before & after headers

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -17,7 +17,7 @@ module.exports = {
   // Slack doesn't support headings, so we'll just make them all bold
   heading: {
     filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
-    replacement: content => `*${content}*`
+    replacement: content => `\n*${content}*\n`
   },
 
   taskListItems: {

--- a/test/fixtures/consecutive-headers.mrkdwn
+++ b/test/fixtures/consecutive-headers.mrkdwn
@@ -1,0 +1,4 @@
+<h1>Header 1</h1><h2>Header 2</h1>
+====
+*Header 1*
+*Header 2*


### PR DESCRIPTION
Fixes #21.

### Before:

In:

```html
<h1>Header1</h1><h2>Header 2</h2>
```

Out:

```
*Header1**Header2*
```

### After

Out:

```

*Header1*

*Header2*

```