### PR TITLE
Add trimAt option, to trim HTML starting at a given selector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,22 @@ mrkdwn(html)
 // }
 ```
 
+You can customize the conversion with some options:
+
+```js
+const mrkdwn = require('html-to-mrkdwn')
+
+const html = `
+<p>Hello</p>
+<hr>
+<p>Goodbye</p>
+`
+
+mrkdwn(html, {trimAt: 'hr'})
+// {
+//   text: "Hello",
+// }
+
+```
+
 [![Greenkeeper badge](https://badges.greenkeeper.io/github-slack/html-to-mrkdwn.svg)](https://greenkeeper.io/)

--- a/lib/first-image.js
+++ b/lib/first-image.js
@@ -1,9 +1,4 @@
-const {JSDOM} = require('jsdom')
-
-module.exports = html => {
-  // Parse the HTML
-  const frag = JSDOM.fragment(html)
-
+module.exports = frag => {
   const img = frag.querySelector('img')
 
   if (img) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const TurnDown = require('turndown')
 const { strikethrough, taskListItems } = require('turndown-plugin-gfm')
 
+const parseHtml = require('./parse-html')
 const firstImage = require('./first-image')
 const rules = require('./rules')
 
@@ -25,9 +26,11 @@ service.use(taskListItems)
 
 Object.keys(rules).forEach(rule => service.addRule(rule, rules[rule]))
 
-module.exports = (html) => {
+module.exports = (html, options) => {
+  options = options || {}
+  const frag = parseHtml(html, {trimAt: options.trimAt})
   return {
-    text: service.turndown(html),
-    image: firstImage(html)
+    text: service.turndown(frag),
+    image: firstImage(frag)
   }
 }

--- a/lib/parse-html.js
+++ b/lib/parse-html.js
@@ -1,0 +1,23 @@
+const {JSDOM} = require('jsdom')
+
+module.exports = (html, options) => {
+  const frag = JSDOM.fragment(html)
+  if (options.trimAt) {
+    const node = frag.querySelector(options.trimAt)
+    if (node) {
+      removeAllStartingAt(node)
+    }
+  }
+  return frag
+}
+
+function removeAllStartingAt (node) {
+  while (node) {
+    let nextNode = node.nextSibling
+    if (!nextNode && node.parentNode) {
+      nextNode = node.parentNode.nextSibling
+    }
+    node.parentNode.removeChild(node)
+    node = nextNode
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-mrkdwn",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Convert HTML to Slack flavored mrkdwn",
   "main": "./lib",
   "scripts": {

--- a/test/fixtures/hr-trim-nested.mrkdwn
+++ b/test/fixtures/hr-trim-nested.mrkdwn
@@ -1,0 +1,8 @@
+<p>
+  Before
+  <hr>
+  After
+</p>
+<p>Really after</p>
+==== {"trimAt": "hr"}
+Before

--- a/test/fixtures/hr-trim.mrkdwn
+++ b/test/fixtures/hr-trim.mrkdwn
@@ -1,0 +1,5 @@
+<p>Before</p>
+<hr>
+<p>After</p>
+==== {"trimAt": "hr"}
+Before

--- a/test/fixtures/hr.mrkdwn
+++ b/test/fixtures/hr.mrkdwn
@@ -1,0 +1,9 @@
+<p>Before</p>
+<hr>
+<p>After</p>
+====
+Before
+
+* * *
+
+After

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,8 +6,9 @@ fs.readdirSync('test/fixtures').forEach(file => {
 
   test(file.replace('.mrkdwn', ''), () => {
     const content = fs.readFileSync(`test/fixtures/${file}`).toString()
-    const [input, output] = content.split('====')
-    expect(mrkdwn(input).text.trim()).toEqual(output.trim())
+    const [input, options, output] = content.split(/^====(.*)$/m)
+    const optionsObject = options ? JSON.parse(options) : undefined
+    expect(mrkdwn(input, optionsObject).text.trim()).toEqual(output.trim())
   })
 })
 


### PR DESCRIPTION
This is needed to extract only the summary when implementing https://github.com/integrations/slack/issues/633 in https://github.com/integrations/slack/pull/637.