### PR TITLE
Bump jest to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "turndown-plugin-gfm": "1.0.1"
   },
   "devDependencies": {
-    "jest": "^22.0.4",
+    "jest": "^23.5.0",
     "standard": "^11.0.0"
   },
   "standard": {


### PR DESCRIPTION
There's a bug that currently causes [all tests to not even run](https://travis-ci.org/integrations/html-to-mrkdwn/builds/418579410?utm_source=github_status&utm_medium=notification).

Bumping Jest to the latest version as suggested [here](https://github.com/facebook/jest/issues/6766)