### PR TITLE
Remove tables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,8 @@ service.escape = (string) => (
 service.use(strikethrough)
 service.use(taskListItems)
 
+service.remove('table')
+
 Object.keys(rules).forEach(rule => service.addRule(rule, rules[rule]))
 
 module.exports = (html) => {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "turndown-plugin-gfm": "1.0.1"
   },
   "devDependencies": {
-    "jest": "^22.0.4",
+    "jest": "^23.5.0",
     "standard": "^11.0.0"
   },
   "standard": {

--- a/test/fixtures/table.mrkdwn
+++ b/test/fixtures/table.mrkdwn
@@ -1,0 +1,2 @@
+<table><thead><tr><th>test</th><th>hello</th><th>hi</th><th>this is</th><th>a table</th></tr></thead><tbody><tr><td>with</td><td>many</td><td>test</td><td>columns</td><td>and</td></tr><tr><td>rows</td><td>ok</td><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td><td>third</td><td>row!</td></tr></tbody></table>
+====


### PR DESCRIPTION
Tables don't show up well at the moment, and making them work well in an environment where we don't have a lot of control over line wrapping (ie. Slack) is pretty difficult. Additionally tables amplify the problem of very large message bodies (due to few characters on each line), which leads to cluttered channels.

Because of that I suggest that we stop rendering tables to mrkdwn for now. I am definitely open to rendering them again in the future, perhaps once we have more control over things like multiple columns in a slack message.

Before this change:
![image](https://user-images.githubusercontent.com/7718702/44395781-d8db5200-a532-11e8-8504-2982d4bc1ff5.png)

After this change:
![image](https://user-images.githubusercontent.com/7718702/44395901-37083500-a533-11e8-9b7b-e58b6ee2ae26.png)
