### PR TITLE
Bump all dependencies

### DIFF
--- a/lib/first-image.js
+++ b/lib/first-image.js
@@ -1,4 +1,4 @@
-const {JSDOM} = require('jsdom')
+const { JSDOM } = require('jsdom')
 
 module.exports = html => {
   // Parse the HTML

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -9,7 +9,7 @@ module.exports = {
     },
 
     replacement: function (content, node) {
-      var href = node.getAttribute('href')
+      const href = node.getAttribute('href')
       return `<${href}|${content}>`
     }
   },
@@ -37,13 +37,13 @@ module.exports = {
         .replace(/^\n+/, '') // remove leading newlines
         .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
         .replace(/\n/gm, '\n    ') // indent
-      var prefix = options.bulletListMarker + ' '
-      var parent = node.parentNode
+      let prefix = options.bulletListMarker + ' '
+      const parent = node.parentNode
       if (node.className.indexOf('task-list-item') >= 0) {
         prefix = ''
       } else if (parent.nodeName === 'OL') {
-        var start = parent.getAttribute('start')
-        var index = Array.prototype.indexOf.call(parent.children, node)
+        const start = parent.getAttribute('start')
+        const index = Array.prototype.indexOf.call(parent.children, node)
         prefix = (start ? Number(start) + index : index + 1) + '. '
       }
       return (
@@ -69,7 +69,7 @@ module.exports = {
 
   highlightedCodeBlock: {
     filter: function (node) {
-      var firstChild = node.firstChild
+      const firstChild = node.firstChild
       return (
         node.nodeName === 'DIV' &&
         /highlight-(?:text|source)-([a-z0-9]+)/.test(node.className) &&

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "homepage": "https://github.com/integrations/html-to-mrkdown#readme",
   "dependencies": {
-    "jsdom": "^11.6.2",
-    "turndown": "^4.0.0-rc.3",
-    "turndown-plugin-gfm": "1.0.1"
+    "jsdom": "^16.4.0",
+    "turndown": "^7.0.0",
+    "turndown-plugin-gfm": "^1.0.2"
   },
   "devDependencies": {
-    "jest": "^23.5.0",
-    "standard": "^11.0.0"
+    "jest": "^26.6.2",
+    "standard": "^16.0.1"
   },
   "standard": {
     "env": [


### PR DESCRIPTION
 Main goal is to get rid of security vulnerabilities in old libraries.

All tests ran well locally. There seems to be no breaking change in dependencies affecting this library.