### PR TITLE
Add support for bold headings

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -20,6 +20,14 @@ module.exports = {
     replacement: content => `\n*${content}*\n`
   },
 
+  strongInHeading: {
+    filter: function (node) {
+      return ['STRONG', 'B'].includes(node.nodeName) &&
+      ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(node.parentNode.nodeName)
+    },
+    replacement: content => content
+  },
+
   taskListItems: {
     filter: function (node) {
       return node.type === 'checkbox' && node.parentNode.nodeName === 'LI'

--- a/test/fixtures/bold-in-heading.mrkdwn
+++ b/test/fixtures/bold-in-heading.mrkdwn
@@ -1,0 +1,13 @@
+<h1><b>heading 1</b></h1>
+<h2><b>heading 2</b></h2>
+<h3><b>heading 3</b></h3>
+<h4><b>heading 4</b></h4>
+<h5><b>heading 5</b></h5>
+<h6><b>heading 6</b></h6>
+====
+*heading 1*
+*heading 2*
+*heading 3*
+*heading 4*
+*heading 5*
+*heading 6*

--- a/test/fixtures/strong-in-heading.mrkdwn
+++ b/test/fixtures/strong-in-heading.mrkdwn
@@ -1,0 +1,13 @@
+<h1><strong>heading 1</strong></h1>
+<h2><strong>heading 2</strong></h2>
+<h3><strong>heading 3</strong></h3>
+<h4><strong>heading 4</strong></h4>
+<h5><strong>heading 5</strong></h5>
+<h6><strong>heading 6</strong></h6>
+====
+*heading 1*
+*heading 2*
+*heading 3*
+*heading 4*
+*heading 5*
+*heading 6*


### PR DESCRIPTION
Hi!

We have a GitHub bot that displays a certain pull request message. In this message we have a bold heading, thus in GitHub integration for Slack, the message appears without being bold with double asterisks on both ends

<img width="469" alt="image" src="https://github.com/integrations/html-to-mrkdwn/assets/4973720/7809ceb9-03b4-4ed1-a657-bff24b6a4e11">

This PR adds a rule that deals with this case. It just returns the content of the strong element if it is a direct child of a heading; thus avoiding the double asterisks.
I also added a condition for the `<b/>` tag. I'm not entirely sure if it is needed but suggestions are of course welcome.
